### PR TITLE
Removing the master-slave lingo

### DIFF
--- a/radio.py
+++ b/radio.py
@@ -55,9 +55,9 @@ class radio:
         except self.serial.serialutil.SerialException as e:
             print("SerialException: " + str(e))
             sys.exit(1)
-    def send(self, dest_addr, pkt_status, pkt_type, pkt_data):
-        self.radio.tx(dest_addr=dest_addr, data=(chr(pkt_status) +            \
-                                                chr(pkt_type) + str(pkt_data)))
+    def send(self, dest_addr, pkt_status, pkt_type, pkt_data=''):
+        self.radio.tx(dest_addr=dest_addr, \
+                      data=(chr(pkt_status) + chr(pkt_type) + str(pkt_data)))
         time.sleep(.1)
     def __del__(self):
         self.radio.halt()

--- a/stream/py_bus_pirate_lite/I2Chigh.py
+++ b/stream/py_bus_pirate_lite/I2Chigh.py
@@ -50,7 +50,7 @@ class I2Chigh(I2C):
 
 
     def command(self, i2caddr, cmd):
-        """ Writes one byte command to slave """
+        """ Writes one byte command to subordinate """
         self.send_start_bit();
         stat = self.bulk_trans(2, [i2caddr<<1, cmd]);
         self.send_stop_bit();


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.